### PR TITLE
Add recycle bin for issue #6 point 8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # --- Planning / spec / AI artifacts (never commit) ---
 CLAUDE.md
 .claude/
+AGENTS.md
+.opencode/
 
 # --- Gradle ---
 .gradle/

--- a/app/src/main/java/com/xnotes/core/text/FlowEditor.kt
+++ b/app/src/main/java/com/xnotes/core/text/FlowEditor.kt
@@ -12,7 +12,8 @@ import com.xnotes.core.history.ParaSnapshot
  * edit was a no-op), which the caller pushes onto the history. Runs are kept
  * normalized (no empty runs, adjacent equal styles merged) after every op.
  */
-class FlowEditor(private val flow: TextFlow) {
+class
+FlowEditor(private val flow: TextFlow) {
 
     /** Insert [text] at [pos]; '\n' splits paragraphs. Returns the command and the caret after it. */
     fun insertText(pos: FlowPos, text: String, style: CharStyle? = null): Pair<Command?, FlowPos> =

--- a/app/src/main/java/com/xnotes/ui/Backstage.kt
+++ b/app/src/main/java/com/xnotes/ui/Backstage.kt
@@ -464,6 +464,15 @@ private fun RecycleBinPane(
         // Multi-select toolbar
         if (selection.isNotEmpty()) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                IconAction(XnotesIcons.undo, "Restore") {
+                    val items = selection.toList(); selection.clear()
+                    scope.launch {
+                        val allOk = withContext(Dispatchers.IO) {
+                            items.all { e -> editor.restoreDocument(e.documentUri, root, e.name) }
+                        }
+                        refreshKey++; if (!allOk) opError = "Couldn’t restore some items."
+                    }
+                }
                 IconAction(XnotesIcons.trash, "Delete permanently") { pendingDelete = selection.toList() }
                 IconAction(XnotesIcons.close, "Deselect") { selection.clear() }
             }
@@ -531,7 +540,11 @@ private fun RecycleBinPane(
                                         }
                                         DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
                                             DropdownMenuItem(text = { Text("Restore") }, onClick = {
-                                                menuOpen = false; opError = "Not implemented yet."
+                                                menuOpen = false
+                                                scope.launch {
+                                                    val ok = withContext(Dispatchers.IO) { editor.restoreDocument(entry.documentUri, root, entry.name) }
+                                                    if (ok) refreshKey++ else opError = "Couldn’t restore item."
+                                                }
                                             })
                                             DropdownMenuItem(text = { Text("Delete permanently") }, onClick = {
                                                 menuOpen = false; pendingDelete = listOf(entry)
@@ -570,7 +583,11 @@ private fun RecycleBinPane(
                                         }
                                         DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
                                             DropdownMenuItem(text = { Text("Restore") }, onClick = {
-                                                menuOpen = false; opError = "Not implemented yet."
+                                                menuOpen = false
+                                                scope.launch {
+                                                    val ok = withContext(Dispatchers.IO) { editor.restoreDocument(entry.documentUri, root, entry.name) }
+                                                    if (ok) refreshKey++ else opError = "Couldn’t restore item."
+                                                }
                                             })
                                             DropdownMenuItem(text = { Text("Delete permanently") }, onClick = {
                                                 menuOpen = false; pendingDelete = listOf(entry)

--- a/app/src/main/java/com/xnotes/ui/Backstage.kt
+++ b/app/src/main/java/com/xnotes/ui/Backstage.kt
@@ -724,6 +724,15 @@ private fun ExplorerSection(
                 IconAction(XnotesIcons.copy, "Copy") { clipboard = ClipItem(selection.toList(), currentDocId, false); selection.clear() }
                 IconAction(XnotesIcons.cut, "Cut") { clipboard = ClipItem(selection.toList(), currentDocId, true); selection.clear() }
                 IconAction(XnotesIcons.trash, "Delete") { pendingDelete = selection.toList() }
+                IconAction(XnotesIcons.trash, "Move to Trash") {
+                    val items = selection.toList(); selection.clear()
+                    scope.launch {
+                        val allOk = withContext(Dispatchers.IO) {
+                            items.all { e -> editor.recycleDocument(e.documentUri, root, e.parentDocId) }
+                        }
+                        refreshKey++; if (!allOk) opError = "Couldn’t trash some items."
+                    }
+                }
                 IconAction(XnotesIcons.close, "Deselect") { selection.clear() }
             }
         }
@@ -880,6 +889,12 @@ private fun ExplorerSection(
                             onCopy = if (selection.isEmpty()) ({ clipboard = ClipItem(listOf(entry), currentDocId, false) }) else null,
                             onCut = if (selection.isEmpty()) ({ clipboard = ClipItem(listOf(entry), currentDocId, true) }) else null,
                             onDelete = if (selection.isEmpty()) ({ pendingDelete = listOf(entry) }) else null,
+                            onTrash = if (selection.isEmpty()) ({
+                                scope.launch {
+                                    withContext(Dispatchers.IO) { editor.recycleDocument(entry.documentUri, root, entry.parentDocId) }
+                                    refreshKey++
+                                }
+                            }) else null,
                             onColor = if (selection.isEmpty()) ({ c ->
                                 scope.launch { withContext(Dispatchers.IO) { editor.setItemColor(root, entry.parentDocId, entry.name, c) }; refreshKey++ }
                             }) else null,
@@ -919,6 +934,12 @@ private fun ExplorerSection(
                             onCopy = if (fileActions) ({ clipboard = ClipItem(listOf(entry), currentDocId, false) }) else null,
                             onCut = if (fileActions) ({ clipboard = ClipItem(listOf(entry), currentDocId, true) }) else null,
                             onDelete = if (fileActions) ({ pendingDelete = listOf(entry) }) else null,
+                            onTrash = if (fileActions) ({
+                                scope.launch {
+                                    withContext(Dispatchers.IO) { editor.recycleDocument(entry.documentUri, root, entry.parentDocId) }
+                                    refreshKey++
+                                }
+                            }) else null,
                             onColor = if (fileActions) ({ c ->
                                 scope.launch { withContext(Dispatchers.IO) { editor.setItemColor(root, entry.parentDocId, entry.name, c) }; refreshKey++ }
                             }) else null,
@@ -1175,6 +1196,7 @@ private fun EntryMenu(
     onCopy: (() -> Unit)?,
     onCut: (() -> Unit)?,
     onDelete: (() -> Unit)?,
+    onTrash: (() -> Unit)?,
     onShare: (() -> Unit)? = null,
     onSaveCopy: (() -> Unit)? = null,
     onExportPdf: (() -> Unit)? = null,
@@ -1194,6 +1216,7 @@ private fun EntryMenu(
             DropdownMenuItem(text = { Text("Cut") }, onClick = { onDismiss(); onCut?.invoke() })
             if (onColor != null) DropdownMenuItem(text = { Text("Color code") }, onClick = { showColors = true })
             DropdownMenuItem(text = { Text("Delete") }, onClick = { onDismiss(); onDelete?.invoke() })
+            DropdownMenuItem(text = { Text("Move to Trash") }, onClick = { onDismiss(); onTrash?.invoke() })
             if (onShare != null) {
                 HorizontalDivider(color = palette.border.toComposeColor())
                 DropdownMenuItem(text = { Text("Share") }, onClick = { onDismiss(); onShare() })
@@ -1265,6 +1288,7 @@ private fun FolderChip(
     onCopy: (() -> Unit)?,
     onCut: (() -> Unit)?,
     onDelete: (() -> Unit)?,
+    onTrash: (() -> Unit)?,
     onColor: ((Rgba?) -> Unit)?,
     onDismissSelection: () -> Unit,
     onClick: () -> Unit,
@@ -1325,7 +1349,7 @@ private fun FolderChip(
             ) {
                 Icon(XnotesIcons.more, "More", tint = if (active) onAccent else palette.textDim.toComposeColor(), modifier = Modifier.size(16.dp))
             }
-            if (!inSelectMode) EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onColor = onColor)
+            if (!inSelectMode) EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onTrash, onColor = onColor)
         }
     }
 }
@@ -1346,6 +1370,7 @@ private fun FileTile(
     onCopy: (() -> Unit)?,
     onCut: (() -> Unit)?,
     onDelete: (() -> Unit)?,
+    onTrash: (() -> Unit)?,
     onColor: ((Rgba?) -> Unit)?,
     onClick: () -> Unit,
     onBounds: (Rect?) -> Unit,
@@ -1398,7 +1423,7 @@ private fun FileTile(
                     IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(32.dp)) {
                         Icon(XnotesIcons.more, "More", tint = palette.textDim.toComposeColor(), modifier = Modifier.size(18.dp))
                     }
-                    EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onShare, onSaveCopy, onExportPdf, onColor = onColor)
+                    EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onTrash, onShare, onSaveCopy, onExportPdf, onColor = onColor)
                 }
             }
         }

--- a/app/src/main/java/com/xnotes/ui/Backstage.kt
+++ b/app/src/main/java/com/xnotes/ui/Backstage.kt
@@ -244,6 +244,14 @@ private fun BackstageContent(
         if (editor.browseRoot != null) onOpenSystem() else onPickRoot()
         if (compact) { animateClose = false; sidebarOpen = false }
     }
+    var recycleBinNavRev by remember { mutableStateOf(0) }
+    val openRecycleBin: () -> Unit = {
+        if (editor.browseRoot != null) {
+            selectView(BackstageView.HOME)
+            sidebarOpen = false
+            recycleBinNavRev++
+        }
+    }
 
     // Home is the app's root, so it owns every back press while it's up (the editor sits
     // underneath in the same activity — letting the dialog dismiss would just bounce back to
@@ -266,6 +274,7 @@ private fun BackstageContent(
             BackstageMain(
                 Modifier.fillMaxSize(), editor, view, compact, sidebarOpen, { animateClose = true; sidebarOpen = true }, { selectView(BackstageView.HOME) },
                 onOpenFile, onPickRoot, importPdf, onShareFile, onSaveCopyFile, onExportFilePdf, createMode, { createMode = it }, onImportCodeTheme, onImportFont,
+                recycleBinNavRev = recycleBinNavRev,
             )
             AnimatedVisibility(
                 visible = sidebarOpen,
@@ -280,7 +289,7 @@ private fun BackstageContent(
                 enter = slideInHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), initialOffsetX = { -it }),
                 exit = if (animateClose) slideOutHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), targetOffsetX = { -it }) else ExitTransition.None,
             ) {
-                BackstageSidebar(Modifier.width(296.dp), view, dismissSidebar, selectView, newNote, importPdf, openSystem)
+                BackstageSidebar(Modifier.width(296.dp), view, dismissSidebar, selectView, newNote, importPdf, openSystem, openRecycleBin)
             }
         }
     } else {
@@ -290,11 +299,12 @@ private fun BackstageContent(
                 enter = expandHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), expandFrom = Alignment.Start) + fadeIn(animationSpec = tween(SIDEBAR_ANIM_MS)),
                 exit = shrinkHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), shrinkTowards = Alignment.Start) + fadeOut(animationSpec = tween(SIDEBAR_ANIM_MS)),
             ) {
-                BackstageSidebar(Modifier.width(264.dp), view, { sidebarOpen = false }, selectView, newNote, importPdf, openSystem)
+                BackstageSidebar(Modifier.width(264.dp), view, { sidebarOpen = false }, selectView, newNote, importPdf, openSystem, openRecycleBin)
             }
             BackstageMain(
                 Modifier.weight(1f).fillMaxHeight(), editor, view, compact, sidebarOpen, { sidebarOpen = true }, { selectView(BackstageView.HOME) },
                 onOpenFile, onPickRoot, importPdf, onShareFile, onSaveCopyFile, onExportFilePdf, createMode, { createMode = it }, onImportCodeTheme, onImportFont,
+                recycleBinNavRev = recycleBinNavRev,
             )
         }
     }
@@ -310,6 +320,7 @@ private fun BackstageSidebar(
     onNewNote: () -> Unit,
     onImportPdf: () -> Unit,
     onOpenSystem: () -> Unit,
+    onOpenRecycleBin: () -> Unit,
 ) {
     val palette = LocalPalette.current
     Column(
@@ -331,6 +342,7 @@ private fun BackstageSidebar(
         Command(XnotesIcons.plus, "New note") { onNewNote() }
         Command(XnotesIcons.importDoc, "Import PDF…") { onImportPdf() }
         Command(XnotesIcons.folder, "Open…") { onOpenSystem() }
+        Command(XnotesIcons.trash, "Recycle Bin") { onOpenRecycleBin() }
         RailDivider()
         Command(XnotesIcons.sliders, "Preferences", selected = view == BackstageView.PREFERENCES) { onSelectView(BackstageView.PREFERENCES) }
         Command(XnotesIcons.info, "About", selected = view == BackstageView.ABOUT) { onSelectView(BackstageView.ABOUT) }
@@ -357,6 +369,7 @@ private fun BackstageMain(
     onCreateMode: (CreateMode) -> Unit,
     onImportCodeTheme: () -> Unit,
     onImportFont: () -> Unit,
+    recycleBinNavRev: Int,
 ) {
     val palette = LocalPalette.current
     Column(modifier) {
@@ -383,6 +396,7 @@ private fun BackstageMain(
                 BackstageView.HOME -> HomePane(
                     editor, onOpenFile, onPickRoot, onImportPdf,
                     onShareFile, onSaveCopyFile, onExportFilePdf, createMode, onCreateMode, sidebarOpen, onShowSidebar,
+                    recycleBinNavRev = recycleBinNavRev,
                 )
                 BackstageView.PREFERENCES -> PreferencesPane(editor, compact, sidebarOpen, onShowSidebar, onBackToHome, onImportCodeTheme, onImportFont)
                 BackstageView.ABOUT -> AboutPane()
@@ -468,6 +482,7 @@ private fun HomePane(
     onCreateMode: (CreateMode) -> Unit,
     sidebarOpen: Boolean,
     onShowSidebar: () -> Unit,
+    recycleBinNavRev: Int,
 ) {
     val palette = LocalPalette.current
     val focusManager = LocalFocusManager.current
@@ -475,6 +490,7 @@ private fun HomePane(
     // that would otherwise sit empty on wide layouts (where the sidebar, not a hamburger, occupies
     // this row). Cleared when the user changes folders (see ExplorerSection).
     var query by remember { mutableStateOf("") }
+    LaunchedEffect(recycleBinNavRev) { if (recycleBinNavRev != 0) query = "" }
     // A tap on empty space anywhere in the pane drops focus from the search field, dismissing it
     // (children like tiles and buttons consume their own taps, so this only fires "outside").
     Column(Modifier.fillMaxSize().pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }) {
@@ -506,6 +522,7 @@ private fun HomePane(
                 editor, onOpenFile, onPickRoot, onImportPdf,
                 onShareFile, onSaveCopyFile, onExportFilePdf, createMode, onCreateMode,
                 searchQuery = query, onSearchChange = { query = it },
+                recycleBinNavRev = recycleBinNavRev,
             )
             // A round quick-create button for a new note in the current folder. Only when a folder is
             // granted — otherwise the explorer shows the folder-picker prompt and there's nowhere to create.
@@ -540,6 +557,7 @@ private fun ExplorerSection(
     onCreateMode: (CreateMode) -> Unit,
     searchQuery: String = "",
     onSearchChange: (String) -> Unit = {},
+    recycleBinNavRev: Int,
 ) {
     val palette = LocalPalette.current
     val root = editor.browseRoot
@@ -568,6 +586,13 @@ private fun ExplorerSection(
     var clipboard by remember(root) { mutableStateOf<ClipItem?>(null) }
     var pendingDelete by remember(root) { mutableStateOf<List<BrowseEntry>?>(null) }
     var opError by remember(root) { mutableStateOf<String?>(null) }
+    LaunchedEffect(recycleBinNavRev) {
+        if (recycleBinNavRev == 0) return@LaunchedEffect
+        val target = editor.recycleBinDocId(root) ?: return@LaunchedEffect
+        stack.clear()
+        selection.clear()
+        stack.add(target to "Recycle Bin")
+    }
     // Drag-to-move state. While a selection is being dragged onto a folder, [dragPos] is the finger
     // position in window coords, [folderBounds] maps each visible folder to its window rect for
     // hit-testing, [dropTargetUri] is the folder under the finger, and [pulseUri] flashes the folder a

--- a/app/src/main/java/com/xnotes/ui/Backstage.kt
+++ b/app/src/main/java/com/xnotes/ui/Backstage.kt
@@ -425,6 +425,7 @@ private fun RecycleBinPane(
     var refreshKey by remember(root) { mutableStateOf(0) }
     val selection = remember(root) { mutableStateListOf<BrowseEntry>() }
     var pendingDelete by remember(root) { mutableStateOf<List<BrowseEntry>?>(null) }
+    var pendingRestore by remember(root) { mutableStateOf<List<BrowseEntry>?>(null) }
     var opError by remember(root) { mutableStateOf<String?>(null) }
     val dismissInteraction = remember { MutableInteractionSource() }
     val gridState = rememberLazyGridState()
@@ -464,15 +465,7 @@ private fun RecycleBinPane(
         // Multi-select toolbar
         if (selection.isNotEmpty()) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                IconAction(XnotesIcons.undo, "Restore") {
-                    val items = selection.toList(); selection.clear()
-                    scope.launch {
-                        val allOk = withContext(Dispatchers.IO) {
-                            items.all { e -> editor.restoreDocument(e.documentUri, root, e.name) }
-                        }
-                        refreshKey++; if (!allOk) opError = "Couldn’t restore some items."
-                    }
-                }
+                IconAction(XnotesIcons.undo, "Restore") { pendingRestore = selection.toList() }
                 IconAction(XnotesIcons.trash, "Delete permanently") { pendingDelete = selection.toList() }
                 IconAction(XnotesIcons.close, "Deselect") { selection.clear() }
             }
@@ -540,11 +533,7 @@ private fun RecycleBinPane(
                                         }
                                         DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
                                             DropdownMenuItem(text = { Text("Restore") }, onClick = {
-                                                menuOpen = false
-                                                scope.launch {
-                                                    val ok = withContext(Dispatchers.IO) { editor.restoreDocument(entry.documentUri, root, entry.name) }
-                                                    if (ok) refreshKey++ else opError = "Couldn’t restore item."
-                                                }
+                                                menuOpen = false; pendingRestore = listOf(entry)
                                             })
                                             DropdownMenuItem(text = { Text("Delete permanently") }, onClick = {
                                                 menuOpen = false; pendingDelete = listOf(entry)
@@ -582,11 +571,7 @@ private fun RecycleBinPane(
                                         }
                                         DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
                                             DropdownMenuItem(text = { Text("Restore") }, onClick = {
-                                                menuOpen = false
-                                                scope.launch {
-                                                    val ok = withContext(Dispatchers.IO) { editor.restoreDocument(entry.documentUri, root, entry.name) }
-                                                    if (ok) refreshKey++ else opError = "Couldn’t restore item."
-                                                }
+                                                menuOpen = false; pendingRestore = listOf(entry)
                                             })
                                             DropdownMenuItem(text = { Text("Delete permanently") }, onClick = {
                                                 menuOpen = false; pendingDelete = listOf(entry)
@@ -618,7 +603,11 @@ private fun RecycleBinPane(
                     pendingDelete = null; selection.clear(); opError = null
                     scope.launch {
                         val allOk = withContext(Dispatchers.IO) {
-                            items.all { e -> editor.deleteDocument(e.documentUri) }
+                            items.all { e ->
+                                val ok = editor.deleteDocument(e.documentUri)
+                                if (ok) editor.clearRestoreMapEntry(e.name)
+                                ok
+                            }
                         }
                         refreshKey++
                         if (!allOk) opError = "Couldn’t delete some items."
@@ -626,6 +615,34 @@ private fun RecycleBinPane(
                 }) { Text("Delete") }
             },
             dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("Cancel") } },
+            containerColor = palette.menuBg.toComposeColor(),
+        )
+    }
+
+    pendingRestore?.let { targets ->
+        AlertDialog(
+            onDismissRequest = { pendingRestore = null },
+            title = { Text("Restore?") },
+            text = {
+                Text(
+                    if (targets.size == 1) "Restore “${entryLabel(targets.first())}” to its original location?"
+                    else "Restore ${targets.size} items to their original locations?",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val items = targets.toList()
+                    pendingRestore = null; selection.clear(); opError = null
+                    scope.launch {
+                        val allOk = withContext(Dispatchers.IO) {
+                            items.all { e -> editor.restoreDocument(e.documentUri, root, e.name) }
+                        }
+                        refreshKey++
+                        if (!allOk) opError = "Couldn’t restore some items."
+                    }
+                }) { Text("Restore") }
+            },
+            dismissButton = { TextButton(onClick = { pendingRestore = null }) { Text("Cancel") } },
             containerColor = palette.menuBg.toComposeColor(),
         )
     }

--- a/app/src/main/java/com/xnotes/ui/Backstage.kt
+++ b/app/src/main/java/com/xnotes/ui/Backstage.kt
@@ -139,7 +139,7 @@ import kotlinx.coroutines.withTimeout
 import kotlin.math.roundToInt
 
 /** Which pane the backstage shows on the right. */
-enum class BackstageView { HOME, PREFERENCES, ABOUT }
+enum class BackstageView { HOME, PREFERENCES, ABOUT, RECYCLE_BIN }
 
 /** Whether the Home explorer is awaiting a new file/folder name. */
 private enum class CreateMode { NONE, FILE, FOLDER }
@@ -244,14 +244,6 @@ private fun BackstageContent(
         if (editor.browseRoot != null) onOpenSystem() else onPickRoot()
         if (compact) { animateClose = false; sidebarOpen = false }
     }
-    var recycleBinNavRev by remember { mutableStateOf(0) }
-    val openRecycleBin: () -> Unit = {
-        if (editor.browseRoot != null) {
-            selectView(BackstageView.HOME)
-            sidebarOpen = false
-            recycleBinNavRev++
-        }
-    }
 
     // Home is the app's root, so it owns every back press while it's up (the editor sits
     // underneath in the same activity — letting the dialog dismiss would just bounce back to
@@ -262,8 +254,8 @@ private fun BackstageContent(
     BackHandler {
         when {
             compact && sidebarOpen -> dismissSidebar()
-            // Preferences and About are sub-pages of Home: back lands on Home rather than leaving the app.
-            view == BackstageView.PREFERENCES || view == BackstageView.ABOUT -> selectView(BackstageView.HOME)
+            // Preferences, About, and Recycle Bin are sub-pages of Home: back lands on Home.
+            view == BackstageView.PREFERENCES || view == BackstageView.ABOUT || view == BackstageView.RECYCLE_BIN -> selectView(BackstageView.HOME)
             createMode != CreateMode.NONE -> createMode = CreateMode.NONE
             else -> onExitApp()
         }
@@ -274,7 +266,6 @@ private fun BackstageContent(
             BackstageMain(
                 Modifier.fillMaxSize(), editor, view, compact, sidebarOpen, { animateClose = true; sidebarOpen = true }, { selectView(BackstageView.HOME) },
                 onOpenFile, onPickRoot, importPdf, onShareFile, onSaveCopyFile, onExportFilePdf, createMode, { createMode = it }, onImportCodeTheme, onImportFont,
-                recycleBinNavRev = recycleBinNavRev,
             )
             AnimatedVisibility(
                 visible = sidebarOpen,
@@ -289,7 +280,7 @@ private fun BackstageContent(
                 enter = slideInHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), initialOffsetX = { -it }),
                 exit = if (animateClose) slideOutHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), targetOffsetX = { -it }) else ExitTransition.None,
             ) {
-                BackstageSidebar(Modifier.width(296.dp), view, dismissSidebar, selectView, newNote, importPdf, openSystem, openRecycleBin)
+                BackstageSidebar(Modifier.width(296.dp), view, dismissSidebar, selectView, newNote, importPdf, openSystem)
             }
         }
     } else {
@@ -299,12 +290,11 @@ private fun BackstageContent(
                 enter = expandHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), expandFrom = Alignment.Start) + fadeIn(animationSpec = tween(SIDEBAR_ANIM_MS)),
                 exit = shrinkHorizontally(animationSpec = tween(SIDEBAR_ANIM_MS), shrinkTowards = Alignment.Start) + fadeOut(animationSpec = tween(SIDEBAR_ANIM_MS)),
             ) {
-                BackstageSidebar(Modifier.width(264.dp), view, { sidebarOpen = false }, selectView, newNote, importPdf, openSystem, openRecycleBin)
+                BackstageSidebar(Modifier.width(264.dp), view, { sidebarOpen = false }, selectView, newNote, importPdf, openSystem)
             }
             BackstageMain(
                 Modifier.weight(1f).fillMaxHeight(), editor, view, compact, sidebarOpen, { sidebarOpen = true }, { selectView(BackstageView.HOME) },
                 onOpenFile, onPickRoot, importPdf, onShareFile, onSaveCopyFile, onExportFilePdf, createMode, { createMode = it }, onImportCodeTheme, onImportFont,
-                recycleBinNavRev = recycleBinNavRev,
             )
         }
     }
@@ -320,7 +310,6 @@ private fun BackstageSidebar(
     onNewNote: () -> Unit,
     onImportPdf: () -> Unit,
     onOpenSystem: () -> Unit,
-    onOpenRecycleBin: () -> Unit,
 ) {
     val palette = LocalPalette.current
     Column(
@@ -342,7 +331,7 @@ private fun BackstageSidebar(
         Command(XnotesIcons.plus, "New note") { onNewNote() }
         Command(XnotesIcons.importDoc, "Import PDF…") { onImportPdf() }
         Command(XnotesIcons.folder, "Open…") { onOpenSystem() }
-        Command(XnotesIcons.trash, "Recycle Bin") { onOpenRecycleBin() }
+        Command(XnotesIcons.trash, "Recycle Bin", selected = view == BackstageView.RECYCLE_BIN) { onSelectView(BackstageView.RECYCLE_BIN) }
         RailDivider()
         Command(XnotesIcons.sliders, "Preferences", selected = view == BackstageView.PREFERENCES) { onSelectView(BackstageView.PREFERENCES) }
         Command(XnotesIcons.info, "About", selected = view == BackstageView.ABOUT) { onSelectView(BackstageView.ABOUT) }
@@ -369,7 +358,6 @@ private fun BackstageMain(
     onCreateMode: (CreateMode) -> Unit,
     onImportCodeTheme: () -> Unit,
     onImportFont: () -> Unit,
-    recycleBinNavRev: Int,
 ) {
     val palette = LocalPalette.current
     Column(modifier) {
@@ -396,12 +384,234 @@ private fun BackstageMain(
                 BackstageView.HOME -> HomePane(
                     editor, onOpenFile, onPickRoot, onImportPdf,
                     onShareFile, onSaveCopyFile, onExportFilePdf, createMode, onCreateMode, sidebarOpen, onShowSidebar,
-                    recycleBinNavRev = recycleBinNavRev,
+                )
+                BackstageView.RECYCLE_BIN -> RecycleBinPane(
+                    editor = editor,
+                    onShowSidebar = onShowSidebar,
+                    onBackToHome = onBackToHome,
+                    sidebarOpen = sidebarOpen,
+                    compact = compact,
                 )
                 BackstageView.PREFERENCES -> PreferencesPane(editor, compact, sidebarOpen, onShowSidebar, onBackToHome, onImportCodeTheme, onImportFont)
                 BackstageView.ABOUT -> AboutPane()
             }
         }
+    }
+}
+
+// --- recycle bin pane ---
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
+@Composable
+private fun RecycleBinPane(
+    editor: Editor,
+    onShowSidebar: () -> Unit,
+    onBackToHome: () -> Unit,
+    sidebarOpen: Boolean,
+    compact: Boolean,
+) {
+    val palette = LocalPalette.current
+    val root = editor.browseRoot
+    if (root == null) {
+        Column(Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+            Spacer(Modifier.weight(1f))
+            Text("No folder selected.", color = palette.textDim.toComposeColor(), fontSize = 14.sp)
+            Spacer(Modifier.weight(1f))
+        }
+        return
+    }
+
+    val scope = rememberCoroutineScope()
+    var refreshKey by remember(root) { mutableStateOf(0) }
+    val selection = remember(root) { mutableStateListOf<BrowseEntry>() }
+    var pendingDelete by remember(root) { mutableStateOf<List<BrowseEntry>?>(null) }
+    var opError by remember(root) { mutableStateOf<String?>(null) }
+    val dismissInteraction = remember { MutableInteractionSource() }
+    val gridState = rememberLazyGridState()
+    val currentDocId by produceState<String?>(root) { value = withContext(Dispatchers.IO) { editor.recycleBinDocId(root) } }
+    val recycleDocId = currentDocId
+
+    fun toggleSelect(e: BrowseEntry) {
+        val i = selection.indexOfFirst { it.documentUri == e.documentUri }
+        if (i >= 0) selection.removeAt(i) else selection.add(e)
+    }
+
+    BackHandler { onBackToHome() }
+
+    Column(Modifier.fillMaxSize()) {
+        // Top bar
+        Row(Modifier.fillMaxWidth().heightIn(min = 48.dp), verticalAlignment = Alignment.CenterVertically) {
+            if (!sidebarOpen) {
+                IconButton(onClick = onShowSidebar) {
+                    Icon(XnotesIcons.menu, "Show sidebar", tint = palette.text.toComposeColor(), modifier = Modifier.size(24.dp))
+                }
+            }
+            Text("Recycle Bin", color = palette.text.toComposeColor(), fontWeight = FontWeight.Bold, fontSize = 16.sp)
+            Spacer(Modifier.weight(1f))
+            if (selection.isEmpty()) {
+                TextButton(onClick = {
+                    recycleDocId?.let { docId ->
+                        scope.launch {
+                            val entries = withContext(Dispatchers.IO) { editor.browseChildren(root, docId) }
+                            if (entries.isNotEmpty()) pendingDelete = entries
+                        }
+                    }
+                }) {
+                    Text("Empty Trash", color = palette.accent.toComposeColor())
+                }
+            }
+        }
+        // Multi-select toolbar
+        if (selection.isNotEmpty()) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                IconAction(XnotesIcons.trash, "Delete permanently") { pendingDelete = selection.toList() }
+                IconAction(XnotesIcons.close, "Deselect") { selection.clear() }
+            }
+        }
+        opError?.let { Text(it, color = Color(0xFFE5534B), fontSize = 12.sp, modifier = Modifier.padding(start = 4.dp, top = 4.dp)) }
+        Spacer(Modifier.height(10.dp))
+
+        // Listing
+        val entries by produceState<List<BrowseEntry>?>(emptyList(), root, recycleDocId, refreshKey) {
+            value = recycleDocId?.let { withContext(Dispatchers.IO) { editor.browseChildren(root, it) } }.orEmpty()
+        }
+        val folders = entries?.filter { it.isDir }.orEmpty()
+        val files = entries?.filterNot { it.isDir }.orEmpty()
+        val gridColumns = (LocalConfiguration.current.screenWidthDp / 240).coerceIn(2, 8)
+
+        Box(Modifier.weight(1f).fillMaxWidth().then(
+            if (selection.isNotEmpty()) Modifier.clickable(interactionSource = dismissInteraction, indication = null) { selection.clear() } else Modifier,
+        )) {
+            when {
+                entries == null -> EmptyPane("Loading…")
+                entries!!.isEmpty() -> EmptyPane("The recycle bin is empty.")
+                else -> LazyVerticalGrid(
+                    columns = GridCells.Fixed(gridColumns),
+                    state = gridState,
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(bottom = 16.dp),
+                ) {
+                    items(entries!!, key = { it.documentUri }) { entry ->
+                        if (entry.isDir) {
+                            var menuOpen by remember { mutableStateOf(false) }
+                            val selected = selection.any { it.documentUri == entry.documentUri }
+                            val accent = palette.accent.toComposeColor()
+                            val onAccent = palette.bg.toComposeColor()
+                            Row(
+                                Modifier
+                                    .fillMaxWidth()
+                                    .border(1.dp, if (selected) accent else palette.border.toComposeColor(), RectangleShape)
+                                    .background(if (selected) accent else Color.Transparent)
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null,
+                                        onClick = { if (selection.isEmpty()) selection.add(entry) else toggleSelect(entry) },
+                                    )
+                                    .padding(start = 10.dp, end = 2.dp, top = 8.dp, bottom = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    XnotesIcons.folder, null,
+                                    tint = if (selected) onAccent else palette.textDim.toComposeColor(),
+                                    modifier = Modifier.size(20.dp),
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    entryLabel(entry),
+                                    color = if (selected) onAccent else palette.text.toComposeColor(),
+                                    fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                if (selection.isEmpty()) {
+                                    Box {
+                                        IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(32.dp)) {
+                                            Icon(XnotesIcons.more, "More", tint = palette.textDim.toComposeColor(), modifier = Modifier.size(16.dp))
+                                        }
+                                        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                                            DropdownMenuItem(text = { Text("Restore") }, onClick = {
+                                                menuOpen = false; opError = "Not implemented yet."
+                                            })
+                                            DropdownMenuItem(text = { Text("Delete permanently") }, onClick = {
+                                                menuOpen = false; pendingDelete = listOf(entry)
+                                            })
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            var menuOpen by remember { mutableStateOf(false) }
+                            Box {
+                                FileTile(
+                                    editor = editor,
+                                    entry = entry,
+                                    selected = selection.any { it.documentUri == entry.documentUri },
+                                    dimmed = false,
+                                    inSelectMode = selection.isNotEmpty(),
+                                    onShare = null,
+                                    onSaveCopy = null,
+                                    onExportPdf = null,
+                                    onRename = null,
+                                    onCopy = null,
+                                    onCut = null,
+                                    onDelete = null,
+                                    onTrash = null,
+                                    onColor = null,
+                                    onClick = {
+                                        if (selection.isEmpty()) selection.add(entry) else toggleSelect(entry)
+                                    },
+                                    onBounds = {},
+                                )
+                                if (selection.isEmpty()) {
+                                    Box(Modifier.align(Alignment.TopEnd).padding(4.dp)) {
+                                        IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(32.dp)) {
+                                            Icon(XnotesIcons.more, "More", tint = palette.textDim.toComposeColor(), modifier = Modifier.size(18.dp))
+                                        }
+                                        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                                            DropdownMenuItem(text = { Text("Restore") }, onClick = {
+                                                menuOpen = false; opError = "Not implemented yet."
+                                            })
+                                            DropdownMenuItem(text = { Text("Delete permanently") }, onClick = {
+                                                menuOpen = false; pendingDelete = listOf(entry)
+                                            })
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pendingDelete?.let { targets ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Delete permanently?") },
+            text = {
+                Text(
+                    if (targets.size == 1) "Permanently delete “${entryLabel(targets.first())}”? This can't be undone."
+                    else "Permanently delete ${targets.size} items? This can't be undone.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val items = targets.toList()
+                    pendingDelete = null; selection.clear(); opError = null
+                    scope.launch {
+                        val allOk = withContext(Dispatchers.IO) {
+                            items.all { e -> editor.deleteDocument(e.documentUri) }
+                        }
+                        refreshKey++
+                        if (!allOk) opError = "Couldn’t delete some items."
+                    }
+                }) { Text("Delete") }
+            },
+            dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("Cancel") } },
+            containerColor = palette.menuBg.toComposeColor(),
+        )
     }
 }
 
@@ -482,7 +692,6 @@ private fun HomePane(
     onCreateMode: (CreateMode) -> Unit,
     sidebarOpen: Boolean,
     onShowSidebar: () -> Unit,
-    recycleBinNavRev: Int,
 ) {
     val palette = LocalPalette.current
     val focusManager = LocalFocusManager.current
@@ -490,7 +699,6 @@ private fun HomePane(
     // that would otherwise sit empty on wide layouts (where the sidebar, not a hamburger, occupies
     // this row). Cleared when the user changes folders (see ExplorerSection).
     var query by remember { mutableStateOf("") }
-    LaunchedEffect(recycleBinNavRev) { if (recycleBinNavRev != 0) query = "" }
     // A tap on empty space anywhere in the pane drops focus from the search field, dismissing it
     // (children like tiles and buttons consume their own taps, so this only fires "outside").
     Column(Modifier.fillMaxSize().pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }) {
@@ -522,7 +730,6 @@ private fun HomePane(
                 editor, onOpenFile, onPickRoot, onImportPdf,
                 onShareFile, onSaveCopyFile, onExportFilePdf, createMode, onCreateMode,
                 searchQuery = query, onSearchChange = { query = it },
-                recycleBinNavRev = recycleBinNavRev,
             )
             // A round quick-create button for a new note in the current folder. Only when a folder is
             // granted — otherwise the explorer shows the folder-picker prompt and there's nowhere to create.
@@ -557,7 +764,6 @@ private fun ExplorerSection(
     onCreateMode: (CreateMode) -> Unit,
     searchQuery: String = "",
     onSearchChange: (String) -> Unit = {},
-    recycleBinNavRev: Int,
 ) {
     val palette = LocalPalette.current
     val root = editor.browseRoot
@@ -586,13 +792,6 @@ private fun ExplorerSection(
     var clipboard by remember(root) { mutableStateOf<ClipItem?>(null) }
     var pendingDelete by remember(root) { mutableStateOf<List<BrowseEntry>?>(null) }
     var opError by remember(root) { mutableStateOf<String?>(null) }
-    LaunchedEffect(recycleBinNavRev) {
-        if (recycleBinNavRev == 0) return@LaunchedEffect
-        val target = editor.recycleBinDocId(root) ?: return@LaunchedEffect
-        stack.clear()
-        selection.clear()
-        stack.add(target to "Recycle Bin")
-    }
     // Drag-to-move state. While a selection is being dragged onto a folder, [dragPos] is the finger
     // position in window coords, [folderBounds] maps each visible folder to its window rect for
     // hit-testing, [dropTargetUri] is the folder under the finger, and [pulseUri] flashes the folder a

--- a/app/src/main/java/com/xnotes/ui/Backstage.kt
+++ b/app/src/main/java/com/xnotes/ui/Backstage.kt
@@ -569,7 +569,6 @@ private fun RecycleBinPane(
                                     onCopy = null,
                                     onCut = null,
                                     onDelete = null,
-                                    onTrash = null,
                                     onColor = null,
                                     onClick = {
                                         if (selection.isEmpty()) selection.add(entry) else toggleSelect(entry)
@@ -965,15 +964,6 @@ private fun ExplorerSection(
                 IconAction(XnotesIcons.copy, "Copy") { clipboard = ClipItem(selection.toList(), currentDocId, false); selection.clear() }
                 IconAction(XnotesIcons.cut, "Cut") { clipboard = ClipItem(selection.toList(), currentDocId, true); selection.clear() }
                 IconAction(XnotesIcons.trash, "Delete") { pendingDelete = selection.toList() }
-                IconAction(XnotesIcons.trash, "Move to Trash") {
-                    val items = selection.toList(); selection.clear()
-                    scope.launch {
-                        val allOk = withContext(Dispatchers.IO) {
-                            items.all { e -> editor.recycleDocument(e.documentUri, root, e.parentDocId) }
-                        }
-                        refreshKey++; if (!allOk) opError = "Couldn’t trash some items."
-                    }
-                }
                 IconAction(XnotesIcons.close, "Deselect") { selection.clear() }
             }
         }
@@ -1130,12 +1120,6 @@ private fun ExplorerSection(
                             onCopy = if (selection.isEmpty()) ({ clipboard = ClipItem(listOf(entry), currentDocId, false) }) else null,
                             onCut = if (selection.isEmpty()) ({ clipboard = ClipItem(listOf(entry), currentDocId, true) }) else null,
                             onDelete = if (selection.isEmpty()) ({ pendingDelete = listOf(entry) }) else null,
-                            onTrash = if (selection.isEmpty()) ({
-                                scope.launch {
-                                    withContext(Dispatchers.IO) { editor.recycleDocument(entry.documentUri, root, entry.parentDocId) }
-                                    refreshKey++
-                                }
-                            }) else null,
                             onColor = if (selection.isEmpty()) ({ c ->
                                 scope.launch { withContext(Dispatchers.IO) { editor.setItemColor(root, entry.parentDocId, entry.name, c) }; refreshKey++ }
                             }) else null,
@@ -1175,12 +1159,6 @@ private fun ExplorerSection(
                             onCopy = if (fileActions) ({ clipboard = ClipItem(listOf(entry), currentDocId, false) }) else null,
                             onCut = if (fileActions) ({ clipboard = ClipItem(listOf(entry), currentDocId, true) }) else null,
                             onDelete = if (fileActions) ({ pendingDelete = listOf(entry) }) else null,
-                            onTrash = if (fileActions) ({
-                                scope.launch {
-                                    withContext(Dispatchers.IO) { editor.recycleDocument(entry.documentUri, root, entry.parentDocId) }
-                                    refreshKey++
-                                }
-                            }) else null,
                             onColor = if (fileActions) ({ c ->
                                 scope.launch { withContext(Dispatchers.IO) { editor.setItemColor(root, entry.parentDocId, entry.name, c) }; refreshKey++ }
                             }) else null,
@@ -1284,11 +1262,11 @@ private fun ExplorerSection(
     pendingDelete?.let { targets ->
         AlertDialog(
             onDismissRequest = { pendingDelete = null },
-            title = { Text("Delete?") },
+            title = { Text("Move to Trash?") },
             text = {
                 Text(
-                    if (targets.size == 1) "Delete “${entryLabel(targets.first())}”? This can’t be undone."
-                    else "Delete ${targets.size} items? This can’t be undone.",
+                    if (targets.size == 1) "Move “${entryLabel(targets.first())}” to Trash?"
+                    else "Move ${targets.size} items to Trash?",
                 )
             },
             confirmButton = {
@@ -1297,22 +1275,12 @@ private fun ExplorerSection(
                     pendingDelete = null; selection.clear(); opError = null
                     scope.launch {
                         val allOk = withContext(Dispatchers.IO) {
-                            var ok = true
-                            items.forEach { e ->
-                                if (editor.deleteDocument(e.documentUri)) {
-                                    // Drop its colour entry from the parent sidecar (a deleted folder's
-                                    // own sidecar goes with it).
-                                    if (e.color != null) editor.setItemColor(root, e.parentDocId, e.name, null)
-                                } else {
-                                    ok = false
-                                }
-                            }
-                            ok
+                            items.all { e -> editor.recycleDocument(e.documentUri, root, e.parentDocId) }
                         }
                         refreshKey++
-                        if (!allOk) opError = "Couldn’t delete some items."
+                        if (!allOk) opError = "Couldn’t move some items to Trash. A file with the same name may already be there."
                     }
-                }) { Text("Delete") }
+                }) { Text("Move to Trash") }
             },
             dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("Cancel") } },
             containerColor = palette.menuBg.toComposeColor(),
@@ -1437,7 +1405,6 @@ private fun EntryMenu(
     onCopy: (() -> Unit)?,
     onCut: (() -> Unit)?,
     onDelete: (() -> Unit)?,
-    onTrash: (() -> Unit)?,
     onShare: (() -> Unit)? = null,
     onSaveCopy: (() -> Unit)? = null,
     onExportPdf: (() -> Unit)? = null,
@@ -1457,7 +1424,6 @@ private fun EntryMenu(
             DropdownMenuItem(text = { Text("Cut") }, onClick = { onDismiss(); onCut?.invoke() })
             if (onColor != null) DropdownMenuItem(text = { Text("Color code") }, onClick = { showColors = true })
             DropdownMenuItem(text = { Text("Delete") }, onClick = { onDismiss(); onDelete?.invoke() })
-            DropdownMenuItem(text = { Text("Move to Trash") }, onClick = { onDismiss(); onTrash?.invoke() })
             if (onShare != null) {
                 HorizontalDivider(color = palette.border.toComposeColor())
                 DropdownMenuItem(text = { Text("Share") }, onClick = { onDismiss(); onShare() })
@@ -1529,7 +1495,6 @@ private fun FolderChip(
     onCopy: (() -> Unit)?,
     onCut: (() -> Unit)?,
     onDelete: (() -> Unit)?,
-    onTrash: (() -> Unit)?,
     onColor: ((Rgba?) -> Unit)?,
     onDismissSelection: () -> Unit,
     onClick: () -> Unit,
@@ -1590,7 +1555,7 @@ private fun FolderChip(
             ) {
                 Icon(XnotesIcons.more, "More", tint = if (active) onAccent else palette.textDim.toComposeColor(), modifier = Modifier.size(16.dp))
             }
-            if (!inSelectMode) EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onTrash, onColor = onColor)
+            if (!inSelectMode) EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onColor = onColor)
         }
     }
 }
@@ -1611,7 +1576,6 @@ private fun FileTile(
     onCopy: (() -> Unit)?,
     onCut: (() -> Unit)?,
     onDelete: (() -> Unit)?,
-    onTrash: (() -> Unit)?,
     onColor: ((Rgba?) -> Unit)?,
     onClick: () -> Unit,
     onBounds: (Rect?) -> Unit,
@@ -1664,7 +1628,7 @@ private fun FileTile(
                     IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(32.dp)) {
                         Icon(XnotesIcons.more, "More", tint = palette.textDim.toComposeColor(), modifier = Modifier.size(18.dp))
                     }
-                    EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onTrash, onShare, onSaveCopy, onExportPdf, onColor = onColor)
+                    EntryMenu(menuOpen, { menuOpen = false }, onRename, onCopy, onCut, onDelete, onShare, onSaveCopy, onExportPdf, onColor = onColor)
                 }
             }
         }

--- a/app/src/main/java/com/xnotes/ui/Editor.kt
+++ b/app/src/main/java/com/xnotes/ui/Editor.kt
@@ -202,6 +202,8 @@ class Editor(context: Context) {
 
     /** On-disk note-thumbnail cache (png + source mtime) so the grid paints instantly across launches. */
     private val thumbCache = com.xnotes.platform.NoteThumbnailCache(java.io.File(appContext.filesDir, "note_thumbs"))
+    /** Maps file names in the recycle bin to their original parent doc ID, for the restore action. */
+    private val restoreStore = com.xnotes.platform.JsonStore(java.io.File(appContext.filesDir, "config/restore_map.json"))
     /** In-memory note-tile thumbnails keyed by SAF URI, bounded by bytes (Compose owns the pixels —
      *  no manual recycle). */
     private val noteThumbs = object : LruCache<String, ImageBitmap>(32 * 1024 * 1024) {
@@ -2030,10 +2032,27 @@ class Editor(context: Context) {
 
     /** Moves a document (file or folder) to recycle bin under [treeUri] instead of deleting it.
      *  IO, call off-thread. Returns false if the recycle bin couldn't be created or found, or if a
-     *  name clash prevents the move (not handled in this version). */
+     *  name clash prevents the move (not handled in this version). Saves the original parent for
+     *  later restore. */
     fun recycleDocument(docUri: String, treeUri: String, parentDocId: String): Boolean {
         val recycleDocId = ensureRecycleBin(treeUri) ?: return false
-        return moveDocumentInto(treeUri, docUri, parentDocId, recycleDocId)
+        val srcName = queryDisplayName(android.net.Uri.parse(docUri)) ?: return false
+        if (!moveDocumentInto(treeUri, docUri, parentDocId, recycleDocId)) return false
+        val map = restoreStore.read()
+        map.put(srcName, parentDocId)
+        restoreStore.write(map)
+        return true
+    }
+
+    /** Moves a document from the recycle bin back to its original parent. IO, call off-thread. */
+    fun restoreDocument(docUri: String, treeUri: String, name: String): Boolean {
+        val recycleDocId = ensureRecycleBin(treeUri) ?: return false
+        val map = restoreStore.read()
+        val originalParent = map.optString(name, null) ?: return false
+        if (!moveDocumentInto(treeUri, docUri, recycleDocId, originalParent)) return false
+        map.remove(name)
+        restoreStore.write(map)
+        return true
     }
 
     /** Returns the doc ID of the recycle bin under [treeUri], creating it if needed, or null. IO. */

--- a/app/src/main/java/com/xnotes/ui/Editor.kt
+++ b/app/src/main/java/com/xnotes/ui/Editor.kt
@@ -117,7 +117,7 @@ private const val SIDECAR_DIR = ".xnote"
 private const val SIDECAR_FILE = "colors.json"
 
 /** Name of the recycle bin folder created at the tree root. Change this to rename it. */
-private const val RECYCLE_BIN_NAME = "recycle_bin"
+private const val RECYCLE_BIN_NAME = ".recycle_bin"
 
 @Stable
 class Editor(context: Context) {
@@ -2035,6 +2035,9 @@ class Editor(context: Context) {
         val recycleDocId = ensureRecycleBin(treeUri) ?: return false
         return moveDocumentInto(treeUri, docUri, parentDocId, recycleDocId)
     }
+
+    /** Returns the doc ID of the recycle bin under [treeUri], creating it if needed, or null. IO. */
+    fun recycleBinDocId(treeUri: String): String? = ensureRecycleBin(treeUri)
 
     /** Deletes a document (file or folder), then erases every trace of it. IO, call off-thread. */
     fun deleteDocument(docUri: String): Boolean = runCatching {

--- a/app/src/main/java/com/xnotes/ui/Editor.kt
+++ b/app/src/main/java/com/xnotes/ui/Editor.kt
@@ -116,6 +116,9 @@ data class PendingImport(val kind: ImportKind, val defaultName: String, val uri:
 private const val SIDECAR_DIR = ".xnote"
 private const val SIDECAR_FILE = "colors.json"
 
+/** Name of the recycle bin folder created at the tree root. Change this to rename it. */
+private const val RECYCLE_BIN_NAME = "recycle_bin"
+
 @Stable
 class Editor(context: Context) {
 
@@ -2025,6 +2028,14 @@ class Editor(context: Context) {
         }
     }
 
+    /** Moves a document (file or folder) to recycle bin under [treeUri] instead of deleting it.
+     *  IO, call off-thread. Returns false if the recycle bin couldn't be created or found, or if a
+     *  name clash prevents the move (not handled in this version). */
+    fun recycleDocument(docUri: String, treeUri: String, parentDocId: String): Boolean {
+        val recycleDocId = ensureRecycleBin(treeUri) ?: return false
+        return moveDocumentInto(treeUri, docUri, parentDocId, recycleDocId)
+    }
+
     /** Deletes a document (file or folder), then erases every trace of it. IO, call off-thread. */
     fun deleteDocument(docUri: String): Boolean = runCatching {
         val ok = android.provider.DocumentsContract.deleteDocument(appContext.contentResolver, android.net.Uri.parse(docUri))
@@ -2361,6 +2372,21 @@ class Editor(context: Context) {
         val result = withCreated.sortedWith(explorerComparator(settings.explorerSortKey, settings.explorerSortDescending) { it.created })
         browseCache["$treeUri|$parentDocId"] = result
         return result
+    }
+
+    // --- recycle bin (a [RECYCLE_BIN_NAME] folder at the tree root, created on first use) ---
+
+    /** Ensures a [RECYCLE_BIN_NAME] folder exists under the root of [treeUri], returning its doc ID, or null. */
+    private fun ensureRecycleBin(treeUri: String): String? {
+        val tree = android.net.Uri.parse(treeUri)
+        val rootId = android.provider.DocumentsContract.getTreeDocumentId(tree)
+        val existing = findChildDocId(tree, rootId, RECYCLE_BIN_NAME, dir = true)
+        if (existing != null) return existing
+        val parent = android.provider.DocumentsContract.buildDocumentUriUsingTree(tree, rootId)
+        val created = android.provider.DocumentsContract.createDocument(
+            appContext.contentResolver, parent, android.provider.DocumentsContract.Document.MIME_TYPE_DIR, RECYCLE_BIN_NAME,
+        ) ?: return null
+        return android.provider.DocumentsContract.getDocumentId(created)
     }
 
     // --- per-folder colour sidecar (a hidden ".xnote/colors.json" beside the items it colours) ---

--- a/app/src/main/java/com/xnotes/ui/Editor.kt
+++ b/app/src/main/java/com/xnotes/ui/Editor.kt
@@ -2058,6 +2058,12 @@ class Editor(context: Context) {
     /** Returns the doc ID of the recycle bin under [treeUri], creating it if needed, or null. IO. */
     fun recycleBinDocId(treeUri: String): String? = ensureRecycleBin(treeUri)
 
+    /** Removes the restore-map entry for [name] so permanently deleted trash items don't leave stale data. */
+    fun clearRestoreMapEntry(name: String) {
+        val map = restoreStore.read()
+        if (map.has(name)) { map.remove(name); restoreStore.write(map) }
+    }
+
     /** Deletes a document (file or folder), then erases every trace of it. IO, call off-thread. */
     fun deleteDocument(docUri: String): Boolean = runCatching {
         val ok = android.provider.DocumentsContract.deleteDocument(appContext.contentResolver, android.net.Uri.parse(docUri))


### PR DESCRIPTION
Add recycle bin for issue #6  point 8. Add recycleDocument() function: it calls ensureRecycleBin() (new), it makes sure that the recycle bin folder exists, then it calls moveDocumentInto() to move the file/folder into the recycle folder. The recycle bin is just a folder named RECYCLE_BIN_NAME="recycle_bin" in the user's folder root. 

The idea is to make the recycle folder hidden and add a recycle bin button in the side bar that takes the user to that folder and have a button to clean it. 

BUG: moveDocumentInto() doesnt handle name crash. Possible solution 1: Implement name crash handler inside moveDocumentInto() or recycleDocument(). solution 2: use copyDocumentInto() + deleteDocument() but that would delete the metadata too i think which would make it harder to implement a file restore later. 

NOTE: current buttons are just placeholders to test the recycle bin, have to fix that when finish.