### PR TITLE
feat(stylus): add support for additional stylus side button tap actions

### DIFF
--- a/app/src/main/java/com/xnotes/settings/Preferences.kt
+++ b/app/src/main/java/com/xnotes/settings/Preferences.kt
@@ -53,6 +53,10 @@ data class Preferences(
      *  key press rather than a held state, e.g. HONOR Magic-Pencil whose click arrives as keycode
      *  333); "none" (default) disables it. */
     val stylusButtonTap: String = "none",
+    /** Action mapped to a momentary stylus side-button click (keycode 92). */
+    val stylusButton1Tap: String = "none",
+    /** Action mapped to a momentary stylus side-button click (keycode 93). */
+    val stylusButton2Tap: String = "none",
     /** Horizontal margin (px) on each side of the page column; 0 ⇒ fit-width fills the screen. */
     val sideMargin: Double = 16.0,
     /** Whether the hairline outline around every page is left undrawn. */
@@ -203,6 +207,8 @@ data class Preferences(
                 threeFingerTap = tapAction("three_finger_tap"),
                 stylusDoubleTap = tapAction("stylus_double_tap"),
                 stylusButtonTap = tapAction("stylus_button_tap"),
+                 stylusButton1Tap = tapAction("stylus_button_1_tap"),
+                 stylusButton2Tap = tapAction("stylus_button_2_tap"),
                 sideMargin = o.optDouble("side_margin", 16.0).coerceIn(0.0, 80.0),
                 hidePageBorders = o.optBoolean("hide_page_borders", false),
                 minZoomEnabled = o.optBoolean("min_zoom_enabled", false),

--- a/app/src/main/java/com/xnotes/ui/Editor.kt
+++ b/app/src/main/java/com/xnotes/ui/Editor.kt
@@ -4241,10 +4241,20 @@ class Editor(context: Context, val pane: Pane = Pane.PRIMARY) : ToolPopupHost, S
     // Some pens report the side button as a momentary vendor key click, not a held state, so it can't
     // drive the hold latch; fire the mapped gesture on key-down, ignore up. HONOR Magic-Pencil 4s ->
     // 333; Lenovo Tab Pen Plus -> 601 (its one code with a clean down; it also emits 600/603/604 ups).
-    private val penButtonTapKeycodes = setOf(333, 601)
+    // Stylus buttons with codes 92 and 93 for additional tap actions.
+    private val penButtonTapKeycodes = setOf(333, 601, 92, 93)
     private fun onPenButtonTapKey(e: android.view.KeyEvent): Boolean {
-        if (preferences.stylusButtonTap == "none") return false
-        if (e.action == android.view.KeyEvent.ACTION_DOWN) dispatchTapGesture(preferences.stylusButtonTap)
+        if (e.action != android.view.KeyEvent.ACTION_DOWN) return false
+        
+        if (e.keyCode == 333 && preferences.stylusButtonTap != "none") {
+            dispatchTapGesture(preferences.stylusButtonTap)
+        } else if (e.keyCode == 601 && preferences.stylusButtonTap != "none") {
+            dispatchTapGesture(preferences.stylusButtonTap)
+        } else if (e.keyCode == 92 && preferences.stylusButton1Tap != "none") {
+            dispatchTapGesture(preferences.stylusButton1Tap)
+        } else if (e.keyCode == 93 && preferences.stylusButton2Tap != "none") {
+            dispatchTapGesture(preferences.stylusButton2Tap)
+        }
         return true
     }
 

--- a/app/src/main/java/com/xnotes/ui/PreferencesPane.kt
+++ b/app/src/main/java/com/xnotes/ui/PreferencesPane.kt
@@ -280,6 +280,12 @@ fun PreferencesPane(
             FieldLabel("Stylus side button (tap)")
             OptionDropdown(tapGestureOptions, prefs.stylusButtonTap) { update(prefs.copy(stylusButtonTap = it)) }
 
+             SectionTitle("Stylus Buttons")
+             FieldLabel("Stylus Button 1 (Keycode 92)")
+             OptionDropdown(tapGestureOptions, prefs.stylusButton1Tap) { update(prefs.copy(stylusButton1Tap = it)) }
+             FieldLabel("Stylus Button 2 (Keycode 93)")
+             HorizontalDivider(color = palette.border.toComposeColor())
+             OptionDropdown(tapGestureOptions, prefs.stylusButton2Tap) { update(prefs.copy(stylusButton2Tap = it)) }
             HorizontalDivider(color = palette.border.toComposeColor())
             SectionTitle("New notes")
             FieldLabel("Filename template")

--- a/app/src/main/java/com/xnotes/ui/PreferencesPane.kt
+++ b/app/src/main/java/com/xnotes/ui/PreferencesPane.kt
@@ -280,12 +280,11 @@ fun PreferencesPane(
             FieldLabel("Stylus side button (tap)")
             OptionDropdown(tapGestureOptions, prefs.stylusButtonTap) { update(prefs.copy(stylusButtonTap = it)) }
 
-             SectionTitle("Stylus Buttons")
-             FieldLabel("Stylus Button 1 (Keycode 92)")
-             OptionDropdown(tapGestureOptions, prefs.stylusButton1Tap) { update(prefs.copy(stylusButton1Tap = it)) }
-             FieldLabel("Stylus Button 2 (Keycode 93)")
-             HorizontalDivider(color = palette.border.toComposeColor())
-             OptionDropdown(tapGestureOptions, prefs.stylusButton2Tap) { update(prefs.copy(stylusButton2Tap = it)) }
+            SectionTitle("Redmi Samrt Pen stylus buttons")
+            FieldLabel("Stylus Button 1")
+            OptionDropdown(tapGestureOptions, prefs.stylusButton2Tap) { update(prefs.copy(stylusButton2Tap = it)) }
+            FieldLabel("Stylus Button 2")
+            OptionDropdown(tapGestureOptions, prefs.stylusButton1Tap) { update(prefs.copy(stylusButton1Tap = it)) }
             HorizontalDivider(color = palette.border.toComposeColor())
             SectionTitle("New notes")
             FieldLabel("Filename template")


### PR DESCRIPTION
Add configuration for stylus buttons with keycodes 92 and 93, allowing users to map custom tap gestures to these buttons. This extends the existing stylus button tap functionality to support more stylus models with additional side buttons.

I built the APK and tested it on my device; everything worked. 

# However, all the changes were made by an AI agent, as I don't know Kotlin and am not an Android developer. Please review the code carefully before merging.